### PR TITLE
Add paredit-kill

### DIFF
--- a/paredit-everywhere.el
+++ b/paredit-everywhere.el
@@ -41,6 +41,7 @@
   (let ((m (make-sparse-keymap)))
     (define-key m (kbd "C-)") 'paredit-forward-slurp-sexp)
     (define-key m (kbd "C-}") 'paredit-forward-barf-sexp)
+    (define-key m (kbd "C-k") 'paredit-kill)
     (define-key m (kbd "M-(") 'paredit-wrap-round)
     (define-key m (kbd "M-{") 'paredit-wrap-curly)
     (define-key m (kbd "M-)") 'paredit-close-round-and-newline)


### PR DESCRIPTION
You can't miss `paredit-kill'.  It does not work for some case, such as
comment block in C, but still very useful for killing string and nested
functions without breaking outer things.
